### PR TITLE
add sodium `mixin.features.item` config in `fabric.mod.json`

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -57,6 +57,9 @@
       "tconstruct:modifier_data",
       "tconstruct:modifiers"
     ],
-    "banner": "Mantle.png"
+    "banner": "Mantle.png",
+    "sodium:options": {
+      "mixin.features.item": false
+    }
   }
 }


### PR DESCRIPTION
```diff
"custom": {
    "cardinal-components": [
      "tconstruct:piggyback",
      "tconstruct:equipment_watcher",
      "tconstruct:persistent_data",
      "tconstruct:modifier_data",
      "tconstruct:modifiers"
    ],
-   "banner": "Mantle.png"
+   "banner": "Mantle.png",
+   "sodium:options": {
+     "mixin.features.item": false
+   }
}
```