### PR TITLE
Fixing chestplate vanishing when using piggy backpack

### DIFF
--- a/src/main/java/slimeknights/tconstruct/gadgets/item/PiggyBackPackItem.java
+++ b/src/main/java/slimeknights/tconstruct/gadgets/item/PiggyBackPackItem.java
@@ -58,8 +58,7 @@ public class PiggyBackPackItem extends TooltipItem {
     if (this.pickupEntity(playerIn, target)) {
       // unequip old armor
       if (chestArmor.getItem() != this) {
-        int piggyBackpackSlot = playerIn.getInventory().findSlotMatchingItem(stack);
-        playerIn.getInventory().add(piggyBackpackSlot, chestArmor);
+        playerIn.getInventory().add(chestArmor);
         chestArmor = ItemStack.EMPTY;
       }
 

--- a/src/main/java/slimeknights/tconstruct/library/recipe/FluidValues.java
+++ b/src/main/java/slimeknights/tconstruct/library/recipe/FluidValues.java
@@ -57,5 +57,6 @@ public final class FluidValues {
 
   // tank capacities
   /** Capacity of a seared or scorched lantern */
-  public static final int LANTERN_CAPACITY = 4050;
+  public static final int SEARED_LANTERN_CAPACITY = 4050;
+  public static final int SCORCHED_LANTERN_CAPACITY = 8100;
 }

--- a/src/main/java/slimeknights/tconstruct/smeltery/TinkerSmeltery.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/TinkerSmeltery.java
@@ -201,14 +201,14 @@ public final class TinkerSmeltery extends TinkerModule {
 
   // seared
   public static final EnumObject<TankType,SearedTankBlock> searedTank = BLOCKS.registerEnum("seared", SearedTankBlock.TankType.values(), type -> new SearedTankBlock(SEARED_NON_SOLID, type.getCapacity()), b -> new TankItem(b, SMELTERY_PROPS, true));
-  public static final ItemObject<SearedLanternBlock> searedLantern = BLOCKS.register("seared_lantern", () -> new SearedLanternBlock(SEARED_LANTERN, FluidValues.LANTERN_CAPACITY), b -> new TankItem(b, SMELTERY_PROPS, false));
+  public static final ItemObject<SearedLanternBlock> searedLantern = BLOCKS.register("seared_lantern", () -> new SearedLanternBlock(SEARED_LANTERN, FluidValues.SEARED_LANTERN_CAPACITY), b -> new TankItem(b, SMELTERY_PROPS, false));
   public static final ItemObject<FaucetBlock> searedFaucet = BLOCKS.register("seared_faucet", () -> new FaucetBlock(SEARED_NON_SOLID), TOOLTIP_BLOCK_ITEM);
   public static final ItemObject<ChannelBlock> searedChannel = BLOCKS.register("seared_channel", () -> new ChannelBlock(SEARED_NON_SOLID), TOOLTIP_BLOCK_ITEM);
   public static final ItemObject<CastingBasinBlock> searedBasin = BLOCKS.register("seared_basin", () -> new CastingBasinBlock(SEARED_NON_SOLID, false), TOOLTIP_BLOCK_ITEM);
   public static final ItemObject<CastingTableBlock> searedTable = BLOCKS.register("seared_table", () -> new CastingTableBlock(SEARED_NON_SOLID, false), TOOLTIP_BLOCK_ITEM);
   // scorched
   public static final EnumObject<TankType,SearedTankBlock> scorchedTank = BLOCKS.registerEnum("scorched", SearedTankBlock.TankType.values(), type -> new SearedTankBlock(SCORCHED_NON_SOLID, type.getCapacity()), b -> new TankItem(b, SMELTERY_PROPS, true));
-  public static final ItemObject<SearedLanternBlock> scorchedLantern = BLOCKS.register("scorched_lantern", () -> new SearedLanternBlock(SCORCHED_LANTERN, FluidValues.LANTERN_CAPACITY), b -> new TankItem(b, SMELTERY_PROPS, false));
+  public static final ItemObject<SearedLanternBlock> scorchedLantern = BLOCKS.register("scorched_lantern", () -> new SearedLanternBlock(SCORCHED_LANTERN, FluidValues.SCORCHED_LANTERN_CAPACITY), b -> new TankItem(b, SMELTERY_PROPS, false));
   public static final ItemObject<FaucetBlock> scorchedFaucet = BLOCKS.register("scorched_faucet", () -> new FaucetBlock(SCORCHED_NON_SOLID), TOOLTIP_BLOCK_ITEM);
   public static final ItemObject<ChannelBlock> scorchedChannel = BLOCKS.register("scorched_channel", () -> new ChannelBlock(SCORCHED_NON_SOLID), TOOLTIP_BLOCK_ITEM);
   public static final ItemObject<CastingBasinBlock> scorchedBasin = BLOCKS.register("scorched_basin", () -> new CastingBasinBlock(SCORCHED_NON_SOLID, true), TOOLTIP_BLOCK_ITEM);

--- a/src/main/java/slimeknights/tconstruct/smeltery/data/SmelteryRecipeProvider.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/data/SmelteryRecipeProvider.java
@@ -855,7 +855,7 @@ public class SmelteryRecipeProvider extends BaseRecipeProvider implements ISmelt
                                  .save(consumer, modResource(folder + "filling/seared_fuel_gauge"));
     ContainerFillingRecipeBuilder.tableRecipe(TinkerSmeltery.searedLantern, FluidValues.NUGGET)
                                  .save(consumer, modResource(folder + "filling/seared_lantern_pixel"));
-    ContainerFillingRecipeBuilder.basinRecipe(TinkerSmeltery.searedLantern, FluidValues.LANTERN_CAPACITY)
+    ContainerFillingRecipeBuilder.basinRecipe(TinkerSmeltery.searedLantern, FluidValues.SEARED_LANTERN_CAPACITY)
                                  .save(consumer, modResource(folder + "filling/seared_lantern_full"));
     // tank filling - scorched
     ContainerFillingRecipeBuilder.basinRecipe(TinkerSmeltery.scorchedTank.get(TankType.INGOT_TANK), FluidValues.INGOT)
@@ -868,7 +868,7 @@ public class SmelteryRecipeProvider extends BaseRecipeProvider implements ISmelt
                                  .save(consumer, modResource(folder + "filling/scorched_fuel_gauge"));
     ContainerFillingRecipeBuilder.tableRecipe(TinkerSmeltery.scorchedLantern, FluidValues.NUGGET)
                                  .save(consumer, modResource(folder + "filling/scorched_lantern_pixel"));
-    ContainerFillingRecipeBuilder.basinRecipe(TinkerSmeltery.scorchedLantern, FluidValues.LANTERN_CAPACITY)
+    ContainerFillingRecipeBuilder.basinRecipe(TinkerSmeltery.scorchedLantern, FluidValues.SCORCHED_LANTERN_CAPACITY)
                                  .save(consumer, modResource(folder + "filling/scorched_lantern_full"));
 
     // Slime

--- a/src/main/java/slimeknights/tconstruct/world/WorldEvents.java
+++ b/src/main/java/slimeknights/tconstruct/world/WorldEvents.java
@@ -184,7 +184,7 @@ public class WorldEvents {
           int weight = Config.COMMON.barterBlazingBlood.get();
           if (weight > 0) {
             injectInto(manager.getLootTable(name), "main", LootItem.lootTableItem(TinkerSmeltery.scorchedLantern).setWeight(weight)
-                                              .apply(SetFluidLootFunction.builder(new FluidStack(TinkerFluids.blazingBlood.get(), FluidValues.LANTERN_CAPACITY)))
+                                              .apply(SetFluidLootFunction.builder(new FluidStack(TinkerFluids.blazingBlood.get(), FluidValues.SCORCHED_LANTERN_CAPACITY)))
                                               .apply(SetItemCountFunction.setCount(UniformGenerator.between(1, 4)))
                                               .build());
           }


### PR DESCRIPTION
I fixed a bug where the chestplate gets vanished when using a piggy backpack, I think this is an issue since I added the chestplate getting placed where the piggy backpack item was.
I also changed scorched lantern's capacity to match the tooltip, so to 100mb of fluid