### PR TITLE
Fix for #159: Game crash when entity melting in an empty smelter with a pipe attached 

### DIFF
--- a/src/main/java/slimeknights/tconstruct/smeltery/block/entity/tank/SmelteryTank.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/block/entity/tank/SmelteryTank.java
@@ -358,7 +358,9 @@ public class SmelteryTank<T extends MantleBlockEntity & ISmelteryTankHandler> ex
         transaction.addOuterCloseCallback((result) -> {
           if (result.wasCommitted()) {
             if (fluid.getAmount() <= 0) {
-              SmelteryTank.this.fluids.remove(slot);
+              if (!SmelteryTank.this.fluids.isEmpty()) {
+                SmelteryTank.this.fluids.remove(slot);
+              }
               parent.notifyFluidsChanged(FluidChange.REMOVED, fluid);
             } else {
               parent.notifyFluidsChanged(FluidChange.CHANGED, fluid);


### PR DESCRIPTION
Fix for issue #159.

The crash in #159 is caused when an item is removed from the fluids list that is already empty, added in a guard which prevents the crash.

Had a build of my fork running on a private server with friends for a couple days with no issues.