### PR TITLE
Update nugget.json

### DIFF
--- a/src/generated/resources/data/tconstruct/recipes/smeltery/melting/metal/iron/nugget.json
+++ b/src/generated/resources/data/tconstruct/recipes/smeltery/melting/metal/iron/nugget.json
@@ -1,7 +1,7 @@
 {
   "type": "tconstruct:melting",
   "ingredient": {
-    "tag": "c:nuggets/iron"
+    "tag": "c:nuggets_iron"
   },
   "result": {
     "amount": 1000,


### PR DESCRIPTION
The tag for the iron nugget was written as "c:nuggests/iron" instead of "c:nuggets_iron" and shows up as a blank recipe in game.