### PR TITLE
Fixed iron nugget melting recipe

### DIFF
--- a/src/generated/resources/data/tconstruct/recipes/smeltery/melting/metal/iron/nugget.json
+++ b/src/generated/resources/data/tconstruct/recipes/smeltery/melting/metal/iron/nugget.json
@@ -1,7 +1,7 @@
 {
   "type": "tconstruct:melting",
   "ingredient": {
-    "tag": "c:nuggets/iron"
+    "tag": "c:nuggets_iron"
   },
   "result": {
     "amount": 1000,

--- a/src/generated/resources/data/tconstruct/recipes/smeltery/melting/metal/iron/nugget.json
+++ b/src/generated/resources/data/tconstruct/recipes/smeltery/melting/metal/iron/nugget.json
@@ -1,7 +1,7 @@
 {
   "type": "tconstruct:melting",
   "ingredient": {
-    "tag": "c:nuggets_iron"
+    "tag": "c:iron_nuggets"
   },
   "result": {
     "amount": 1000,


### PR DESCRIPTION
Tag for iron nugget was wrong and resulted in a blank recipe in EMI as well as an inability to smelt iron nuggets. Have tested in game and is now functional.